### PR TITLE
Use restic from alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,8 +2,9 @@ FROM rclone/rclone:1.65 as rclone
 
 FROM alpine:latest
 COPY --from=rclone /usr/local/bin/rclone /usr/local/bin/rclone
-RUN apk --no-cache add ca-certificates curl bash openssh
+RUN apk --no-cache add ca-certificates curl bash openssh restic
 RUN mkdir -p /tmp
 
+ENV BACKREST_RESTIC_COMMAND=/usr/bin/restic
 ENTRYPOINT ["/backrest"]
 COPY backrest /backrest


### PR DESCRIPTION
Backrest retrieves the restic package if no environment variable to the binary is set and places this in /data which is a docker volume. In my case but perhaps not limited to me this is a noexec mount  and/or it can clash with selinux. 

This patch  installs  restic from alpine in the docker image.